### PR TITLE
Here are some arguments in favor of not committing node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+node_modules


### PR DESCRIPTION
You keep your Git history clean. When you add a new package, you store the package.json and package-lock.json file changes. When you decide to update the package version, all you store is the package-lock.json file change.

package-lock.json is a relatively new feature of npm, that obsoletes the shrinkwrap command used in the past

You avoid having to put possibly hundreds of MB of dependencies in your repository, and this means that over time it will be faster to work with. Switching branches and checking out the code are 2 operations hugely affected by the repository size.

When working with branches, you might have merge conflicts that extend beyond your code, and instead, involve dependencies code. This is not nice to deal with and might make you lose a lot of time. Avoiding putting

A pull request or merge if changing the dependencies, is going to have much more files involved in the process. Tools become slower or even decide to not show the full diff (GitHub, for example)

Native node modules need to be recompiled if you deploy to a platform different than your development machine(common use case: you develop on Mac, deploy on Linux). You need to call npm rebuild, which takes the server out of sync.

Not committing node_modules implies you need to list all your modules in the package.json (and package-lock.json) as a mandatory step. This is great because you might not have the diligence to do so, and some of the npm operations might break if you don’t.